### PR TITLE
Drop remnant uses of paperlib

### DIFF
--- a/Essentials/src/main/java/com/earth2me/essentials/AsyncTeleport.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/AsyncTeleport.java
@@ -5,7 +5,6 @@ import com.earth2me.essentials.commands.WarpNotFoundException;
 import com.earth2me.essentials.utils.DateUtil;
 import com.earth2me.essentials.utils.LocationUtil;
 import io.canvasmc.canvas.event.PlayerRespawnAsyncEvent;
-import io.papermc.lib.PaperLib;
 import net.ess3.api.IEssentials;
 import net.ess3.api.IUser;
 import net.ess3.api.TranslatableException;
@@ -135,7 +134,7 @@ public class AsyncTeleport implements IAsyncTeleport {
 
     @Override
     public void nowUnsafe(Location loc, TeleportCause cause, CompletableFuture<Boolean> future) {
-        final CompletableFuture<Boolean> paperFuture = PaperLib.teleportAsync(teleportOwner.getBase(), loc, cause);
+        final CompletableFuture<Boolean> paperFuture = teleportOwner.getBase().teleportAsync(loc, cause);
         paperFuture.thenAccept(future::complete);
         paperFuture.exceptionally(future::completeExceptionally);
     }
@@ -174,15 +173,15 @@ public class AsyncTeleport implements IAsyncTeleport {
             targetLoc.setZ(LocationUtil.getZInsideWorldBorder(targetLoc.getWorld(), targetLoc.getBlockZ()));
         }
         ess.scheduleLocationDelayedTask(targetLoc, () ->
-                PaperLib.getChunkAtAsync(targetLoc.getWorld(), targetLoc.getBlockX() >> 4, targetLoc.getBlockZ() >> 4, true, true).thenAccept(chunk -> {
+                targetLoc.getWorld().getChunkAtAsync(targetLoc.getBlockX() >> 4, targetLoc.getBlockZ() >> 4, true, true).thenAccept(chunk -> {
                     if (LocationUtil.isBlockUnsafeForUser(ess, teleportee, targetLoc.getWorld(), targetLoc.getBlockX(), targetLoc.getBlockY(), targetLoc.getBlockZ())) {
                         if (ess.getSettings().isTeleportSafetyEnabled()) {
                             if (ess.getSettings().isForceDisableTeleportSafety()) {
-                                PaperLib.teleportAsync(teleportee.getBase(), targetLoc, cause);
+                                teleportee.getBase().teleportAsync(targetLoc, cause);
                             } else {
                                 try {
                                     //There's a chance the safer location is outside the loaded chunk so still teleport async here.
-                                    PaperLib.teleportAsync(teleportee.getBase(), LocationUtil.getSafeDestination(ess, teleportee, targetLoc), cause);
+                                    teleportee.getBase().teleportAsync(LocationUtil.getSafeDestination(ess, teleportee, targetLoc), cause);
                                 } catch (final Exception e) {
                                     future.completeExceptionally(e);
                                     return;
@@ -194,14 +193,14 @@ public class AsyncTeleport implements IAsyncTeleport {
                         }
                     } else {
                         if (ess.getSettings().isForceDisableTeleportSafety()) {
-                            PaperLib.teleportAsync(teleportee.getBase(), targetLoc, cause);
+                            teleportee.getBase().teleportAsync(targetLoc, cause);
                         } else {
                             Location dest = targetLoc;
                             if (ess.getSettings().isTeleportToCenterLocation()) {
                                 dest = LocationUtil.getRoundedDestination(targetLoc);
                             }
                             // There's a *small* chance the rounded destination produces a location outside the loaded chunk so still teleport async here.
-                            PaperLib.teleportAsync(teleportee.getBase(), dest, cause);
+                            teleportee.getBase().teleportAsync(dest, cause);
                         }
                     }
                     future.complete(true);

--- a/Essentials/src/main/java/com/earth2me/essentials/EssentialsPlayerListener.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/EssentialsPlayerListener.java
@@ -15,7 +15,6 @@ import com.earth2me.essentials.utils.FormatUtil;
 import com.earth2me.essentials.utils.LocationUtil;
 import com.earth2me.essentials.utils.MaterialUtil;
 import com.earth2me.essentials.utils.VersionUtil;
-import io.papermc.lib.PaperLib;
 import io.papermc.paper.ban.BanListType;
 import io.papermc.paper.event.connection.configuration.AsyncPlayerConnectionConfigureEvent;
 import io.papermc.paper.event.player.PlayerServerFullCheckEvent;
@@ -1033,7 +1032,7 @@ public class EssentialsPlayerListener implements Listener {
                     while (LocationUtil.isBlockDamaging(loc.getWorld(), loc.getBlockX(), loc.getBlockY() - 1, loc.getBlockZ())) {
                         loc.setY(loc.getY() + 1d);
                     }
-                    PaperLib.teleportAsync(user.getBase(), loc, TeleportCause.PLUGIN);
+                    user.getBase().teleportAsync(loc, TeleportCause.PLUGIN);
                 }
             }
 

--- a/Essentials/src/main/java/com/earth2me/essentials/RandomTeleport.java
+++ b/Essentials/src/main/java/com/earth2me/essentials/RandomTeleport.java
@@ -5,7 +5,6 @@ import com.earth2me.essentials.config.EssentialsConfiguration;
 import com.earth2me.essentials.config.entities.LazyLocation;
 import com.earth2me.essentials.utils.LocationUtil;
 import com.earth2me.essentials.utils.VersionUtil;
-import io.papermc.lib.PaperLib;
 import net.ess3.provider.BiomeKeyProvider;
 import net.ess3.provider.BiomeNameProvider;
 import net.ess3.provider.WorldInfoProvider;
@@ -214,7 +213,7 @@ public class RandomTeleport implements IConf {
             360 * RANDOM.nextFloat() - 180,
             0
         );
-        PaperLib.getChunkAtAsync(location).thenAccept(chunk -> {
+        location.getWorld().getChunkAtAsync(location).thenAccept(chunk -> {
             if (World.Environment.NETHER.equals(center.getWorld().getEnvironment())) {
                 location.setY(getNetherYAt(location));
             } else {


### PR DESCRIPTION
Remove a bunch of paperlib still left over after commit ad49481. Fixes "java.lang.UnsupportedOperationException: Must use teleportAsync while in region threading" being thrown on an attempted teleport.